### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kristentr/kryo/security/code-scanning/2](https://github.com/kristentr/kryo/security/code-scanning/2)

To fix this issue, add a top-level `permissions` block to the workflow file `.github/workflows/node.js.yml`, just after the `name` and before the `on:` key. The block should limit permissions to only those required for the build and test jobs. Since none of the actions used require write permissions to repository contents, the minimal appropriate permissions block is:
```yaml
permissions:
  contents: read
```
This will ensure the GITHUB_TOKEN in this workflow has only read access to repository contents, reducing the risk of privilege escalation or unintended changes. No changes to the job steps or logic are needed. The edit should be made immediately after the `name:` block (i.e., after line 4).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
